### PR TITLE
Update kbs configuration

### DIFF
--- a/config/samples/kbs-config.yaml
+++ b/config/samples/kbs-config.yaml
@@ -6,10 +6,30 @@ metadata:
 data:
   kbs-config.json: |
     {
-        "repository_type": "LocalFs",
-        "repository_description": {
-            "dir_path": "/opt/confidential-containers/kbs/repository"
+        "insecure_http" : true,
+        "sockets": ["0.0.0.0:8080"],
+        "auth_public_key": "/etc/auth-secret/kbs.pem",
+        "attestation_token_config": {
+          "attestation_token_type": "CoCo"
         },
-        "attestation_token_type": "Simple",
-        "as_config_file_path": "/etc/as-config/as-config.json"
+        "repository_config": {
+          "type": "LocalFs",
+          "dir_path": "/opt/confidential-containers/kbs/repository"
+        },
+        "as_config": {
+          "work_dir": "/opt/confidential-containers/attestation-service",
+          "policy_engine": "opa",
+          "rvps_store_type": "LocalFs",
+          "attestation_token_broker": "Simple",
+          "attestation_token_config": {
+            "duration_min": 5
+          },
+          "rvps_config": {
+            "store_type": "LocalFs",
+            "remote_addr": ""
+          }
+        },
+        "policy_engine_config": {
+          "policy_path": "/opa/confidential-containers/kbs/policy.rego"
+        }
     }

--- a/config/samples/kbsconfig_sample.yaml
+++ b/config/samples/kbsconfig_sample.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: kbs-operator-system
 spec:
   kbsConfigMapName: kbs-config
-  kbsAsConfigMapName: as-config
+  #kbsAsConfigMapName: as-config
   #kbsRvpsConfigMapName: rvps-config
   kbsAuthSecretName: kbs-auth-public-key
 

--- a/controllers/kbsconfig_controller.go
+++ b/controllers/kbsconfig_controller.go
@@ -455,13 +455,8 @@ func (r *KbsConfigReconciler) newKbsDeployment(ctx context.Context) *appsv1.Depl
 	// command array for the KBS container
 	command := []string{
 		"/usr/local/bin/kbs",
-		"--socket",
-		"0.0.0.0:8080",
-		"--config",
+		"--config-file",
 		"/etc/kbs-config/kbs-config.json",
-		"--auth-public-key",
-		"/etc/auth-secret/kbs.pem",
-		"--insecure-http",
 	}
 
 	// RunAsUser (root) 0


### PR DESCRIPTION
This PR updates the KBS configuration for being compatible with the latest all-in-one KBS image.

Please note the authentication key is provided as part of the kbs-config.yaml file, not sure  how to consume the secret `kbsAuthSecretName: kbs-auth-public-key`